### PR TITLE
add modal-open class when showOverlay is true

### DIFF
--- a/dist/mkModal.js
+++ b/dist/mkModal.js
@@ -86,7 +86,9 @@
             return init(newValue);
           }, true);
           return $triggerElement.on("click", function(el) {
-            scope.$body.addClass("modal-open");
+            if (scope.data.showOverlay) {
+              scope.$body.addClass("modal-open");
+            }
             scope.$modal.addClass("mkmd-show");
             $overlay.off("click", removeModalHandler);
             return $overlay.on("click", removeModalHandler);

--- a/example/dist/mkModal.js
+++ b/example/dist/mkModal.js
@@ -86,7 +86,9 @@
             return init(newValue);
           }, true);
           return $triggerElement.on("click", function(el) {
-            scope.$body.addClass("modal-open");
+            if (scope.data.showOverlay) {
+              scope.$body.addClass("modal-open");
+            }
             scope.$modal.addClass("mkmd-show");
             $overlay.off("click", removeModalHandler);
             return $overlay.on("click", removeModalHandler);

--- a/src/mkModal.coffee
+++ b/src/mkModal.coffee
@@ -95,7 +95,7 @@ angular.module("mkModal", []).directive "mkModal", () ->
 
         $triggerElement.on("click", (el) ->
 
-          scope.$body.addClass("modal-open");
+          scope.$body.addClass("modal-open") if scope.data.showOverlay
           scope.$modal.addClass("mkmd-show")
           $overlay.off("click", removeModalHandler)
           $overlay.on("click", removeModalHandler)


### PR DESCRIPTION
狀況 :: 

不要秀 overlay 的時候會造成 scroll 消失

原因 ::

/\* For locking screen when modal is open */
.modal-open {
  overflow: hidden;
}

解:: 

增加判斷在需要 showOverlay 的情況下才加上 modal-open

```
$triggerElement.on("click", (el) ->

          scope.$body.addClass("modal-open") if scope.data.showOverlay
          scope.$modal.addClass("mkmd-show")
          $overlay.off("click", removeModalHandler)
          $overlay.on("click", removeModalHandler)
```

(同時有對 mak 的套件作 pr)
